### PR TITLE
Use explicit None check for embeddings array

### DIFF
--- a/knowledge_base.py
+++ b/knowledge_base.py
@@ -202,7 +202,7 @@ class KnowledgeBase:
         """
         import numpy as np
         
-        if not self.embeddings:
+        if self.embeddings is None:
             # If embeddings aren't generated yet, return some basic commands
             return self.commands[:min(top_n, len(self.commands))]
         


### PR DESCRIPTION
## Summary
- Avoid NumPy truthiness errors by checking `self.embeddings is None` in `find_relevant_commands`
- Confirmed no other NumPy array truthiness checks remain via repo-wide search

## Testing
- `python -m py_compile knowledge_base.py`


------
https://chatgpt.com/codex/tasks/task_e_6890770bcb8c832c91f3c4df6e0abcc7